### PR TITLE
Run VSCode in shell mode to ensure paths are expanded correctly.

### DIFF
--- a/krunner_vscode/__main__.py
+++ b/krunner_vscode/__main__.py
@@ -95,8 +95,8 @@ class Runner(dbus.service.Object):
     def Run(self, data: str, action_id: str):
         subprocess.run([
             "code" if not action_id else "xdg-open",
-            data
-        ])
+            str(data)
+        ], shell=True)
 
 runner = Runner()
 loop = GLib.MainLoop()


### PR DESCRIPTION
This could have been done manually, but relying on the shell should cover more edge cases